### PR TITLE
node version bump to 16

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -18,5 +18,5 @@ inputs:
     description: 'TKE cluster id'
     required: true
 runs:
-  using: 'node12'
+  using: 'node16'
   main: 'index.js'


### PR DESCRIPTION
node12 is been deprecated in the GitHub action flow, which triggers warning every time